### PR TITLE
Upgrade uxarray to 2025.12.0 and bug fixes

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ twine==1.14.0
 Click==7.1.2
 pytest==6.2.4
 shapely>=2.0
-uxarray==2025.6.0
+uxarray==2025.12.0
 netcdf>=1.6
 xarray>=2023.4.1
 holoviews>=1.16.0

--- a/suxarray/core/dataarray.py
+++ b/suxarray/core/dataarray.py
@@ -18,6 +18,14 @@ class SxDataArray(uxarray.UxDataArray):
         if sxgrid is not None and not isinstance(sxgrid, Grid):
             raise RuntimeError("sxgrid must be a Grid object")
 
+        # temporary fix to avoid passing uxgrid to parent class through kwargs.
+        if "uxgrid" in kwargs:  # check if uxgrid is in kwargs
+            if isinstance(kwargs["uxgrid"], Grid):  # type check
+                sxgrid = kwargs["uxgrid"]  # assign to sxgrid
+                kwargs.pop(
+                    "uxgrid"
+                )  # remove uxgrid from kwargs to avoid passing it to parent class
+
         super().__init__(*args, uxgrid=sxgrid, **kwargs)
 
     subset = UncachedAccessor(DataArraySubsetAccessor)
@@ -31,7 +39,6 @@ class SxDataArray(uxarray.UxDataArray):
         if not ignore_grid and self.uxgrid.sgrid_info is not None:
             da_new.uxgrid = da_new.uxgrid.sgrid_isel(**kwargs)
         return da_new
-
 
     def depth_average(self) -> SxDataArray:
         """Calculate depth-average of a variable


### PR DESCRIPTION
Upgrades the uxarray dependency from 2025.6.0 to 2025.12.0.

Bugfix: In SxDataArray.__init__ pop uxgrid from kwargs (if present) and assign it to sxgrid so the parent UxDataArray reconstruction paths (e.g., isel) no longer produce multiple-value/type errors.

Bugfix: in _schismgrid._rename_coords add checks to rename SCHISM dimensions to n_edge, n_face, n_node as uxarray.io._read_ugrid does not consistently rename dimensions.