### PR TITLE
fix: rename SCHISM geographic coords in _rename_coords for uxarray ≥ 2025.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "uxarray==2025.6.0",
+    "uxarray==2025.12.0",
     "shapely>=2.0",
     "Click>=7.0"
 ]

--- a/suxarray/io/_schismgrid.py
+++ b/suxarray/io/_schismgrid.py
@@ -357,6 +357,16 @@ def _rename_coords(
         }
         data = data.rename(coord_dict)
     # Patch for dimension name renaming.
+    if "SCHISM_hgrid_node_lon" in data:
+        data = data.rename({"SCHISM_hgrid_node_lon": "node_lon",
+                            "SCHISM_hgrid_node_lat": "node_lat"})
+    if "SCHISM_hgrid_face_lon" in data:
+        data = data.rename({"SCHISM_hgrid_face_lon": "face_lon",
+                            "SCHISM_hgrid_face_lat": "face_lat"})
+    if "SCHISM_hgrid_edge_lon" in data:
+        data = data.rename({"SCHISM_hgrid_edge_lon": "edge_lon",
+                            "SCHISM_hgrid_edge_lat": "edge_lat"})
+
     if "nSCHISM_hgrid_edge" in data.dims:
         data = data.rename({"nSCHISM_hgrid_edge": "n_edge"})
     if "nSCHISM_hgrid_face" in data.dims:


### PR DESCRIPTION
uxarray's _read_ugrid gained an outer existence guard between v2025.06.0 and v2025.08.0: face/edge coordinate renaming via the face_coordinates UGRID attribute now only fires if variables literally named "face_lon"/"face_lat" already exist in the dataset. Since suxarray stores pre-transformed coordinates as SCHISM_hgrid_face_lon/lat (not face_lon/lat), the rename was silently skipped, leaving face_lon absent from _ds.

Without face_lon, uxarray's _populate_face_centroids falls back to the Cartesian branch. It finds face_x in _ds (UTM easting, renamed by _rename_coords) and grabs face_y (UTM northing) and face_z (SCHISM bottom-layer depth in negative meters, stored by _assign_z_coords) as if they were unit-sphere Cartesian coordinates. It then calls:

    lat = arcsin(face_z)   # arcsin only defined for z ∈ [-1, 1]

arctan2 used for lon never produces NaN, so face_lon is unaffected. arcsin on depth values outside [-1, 1] produces NaN, so only face_lat is corrupted. On the Bay-Delta test domain, about ~4% (~21K of 538K) faces get corrupted.

Fix: add explicit SCHISM_hgrid_{node,face,edge}_lon/lat → {node,face,edge}_lon/lat renaming in _rename_coords with if-guards. Under uxarray 2025.06, _read_ugrid already consumed these names so the guards are false (no-op). Under 2025.08+, the rename ensures face_lon is present in _ds before uxarray's lazy centroid property fires, taking _populate_face_centroids down the correct else-branch (converts existing face_lon/lat to face_x/y/z) with no recomputation.

Additionally, the uxarray dependency version in pyproj.toml was brought up to 2025.12.0