### PR TITLE
Fix: pass ds_data as dictionary in read_schism_nc to circumvent xarray guard on xr.Dataset parameter

### DIFF
--- a/suxarray/core/api.py
+++ b/suxarray/core/api.py
@@ -19,7 +19,7 @@ def read_schism_nc(grid: Grid, ds_data: xr.Dataset) -> SxDataset:
     ds_data = ux.core.utils._map_dims_to_ugrid(ds_data, grid._source_dims_dict, grid)
     if "nSCHISM_vgrid_layers" in ds_data.dims:
         ds_data = ds_data.swap_dims({"nSCHISM_vgrid_layers": "n_layer"})
-    sxds = SxDataset(dict(ds_data.data_vars), sxgrid=grid)
+    sxds = SxDataset(dict(ds_data.data_vars), sxgrid=grid, attrs=ds_data.attrs)
     return sxds
 
 

--- a/suxarray/core/api.py
+++ b/suxarray/core/api.py
@@ -19,7 +19,7 @@ def read_schism_nc(grid: Grid, ds_data: xr.Dataset) -> SxDataset:
     ds_data = ux.core.utils._map_dims_to_ugrid(ds_data, grid._source_dims_dict, grid)
     if "nSCHISM_vgrid_layers" in ds_data.dims:
         ds_data = ds_data.swap_dims({"nSCHISM_vgrid_layers": "n_layer"})
-    sxds = SxDataset(ds_data, sxgrid=grid)
+    sxds = SxDataset(dict(ds_data.data_vars), sxgrid=grid)
     return sxds
 
 

--- a/tests/test_suxarray.py
+++ b/tests/test_suxarray.py
@@ -30,6 +30,34 @@ def test_read_schism_nc():
     assert sxds.time.size == 48
 
 
+def test_read_schism_nc_preserves_attrs():
+    """
+    Test conservation of dataset-level attrs in read_schism_nc.
+    """
+    p_cur = Path(__file__).parent.absolute()
+    ds_out2d = xr.open_dataset(str(p_cur / "testdata/out2d_1.nc"))
+    ds_zcoords = xr.open_dataset(str(p_cur / "testdata/zCoordinates_1.nc"))
+    grid = sx.read_grid(ds_out2d, ds_zcoords)
+    ds_data = xr.open_dataset(str(p_cur / "testdata/salinity_1.nc"))
+
+    # Attach sample global attributes to the source dataset.
+    sample_attrs = {
+        "Conventions": "CF-1.0",
+        "title": "Bay-Delta SCHISM salinity output",
+        "source": "SCHISM",
+    }
+    ds_data.attrs = sample_attrs
+
+    sxds = sx.read_schism_nc(grid, ds_data)
+
+    # The global attributes must survive the round trip.
+    for key, value in sample_attrs.items():
+        assert sxds.attrs.get(key) == value
+
+    # The data variable must still be intact.
+    assert "salinity" in sxds
+
+
 def test_read_hgrid_gr3():
     """Test read_hgrid_gr3"""
     # Test with a HelloSCHISM v5.10 hgrid.gr3 file


### PR DESCRIPTION
Calling `sx.read_schism_nc(grid, ds_data)` raises:

```
TypeError: Passing a Dataset as `data_vars` to the Dataset constructor is not supported.
Use `ds.copy()` to create a copy of a Dataset.
```

**Root**

In `read_schism_nc`, ds_data (an `xr.Dataset`) is passed as positional argument to `SxDataset` which forwards it via `*args` through `ux.UxDataset.__init__` down to `xr.Dataset.__init__`, where it lands in the data_vars parameter.

Newer versions of xarray (here 2026.4.0) added an explicit isinstance guard:
```
if isinstance(data_vars, Dataset):
    raise TypeError(...)
```

The error message is misleading however, as using ds_data.copy() instead in `read_schism_nc`  creates another `xr.Dataset`, triggering the isinstance guard anyway.

**Fix**

Passing the data as a dictionary circumvents the guard, with dimension coordinates (such as time) being preserved.